### PR TITLE
Default to 'now' if no command is specified (fixes #13)

### DIFF
--- a/org-doing.el
+++ b/org-doing.el
@@ -96,6 +96,9 @@ The first part of the `command' string is parsed as a command:
 - now: calls `org-doing-log'
 - later: calls `org-doing-log'
 - done: calls `org-doing-done'
+
+If no match is found, `org-doing-log' is called and passed the entire
+command string.
 "
   (interactive "sDoing? ")
   (let* ((first-space (search " " command))
@@ -105,7 +108,8 @@ The first part of the `command' string is parsed as a command:
                  nil)))
     (cond ((string= cmd "now") (org-doing-log args))
           ((string= cmd "later") (org-doing-log args t))
-          ((string= cmd "done") (org-doing-done args)))))
+          ((string= cmd "done") (org-doing-done args))
+          (t (org-doing-log (concat cmd " " args))))))
 
 
 (provide 'org-doing)

--- a/org-doing.el
+++ b/org-doing.el
@@ -109,7 +109,7 @@ command string.
     (cond ((string= cmd "now") (org-doing-log args))
           ((string= cmd "later") (org-doing-log args t))
           ((string= cmd "done") (org-doing-done args))
-          (t (org-doing-log (concat cmd " " args))))))
+          (t (org-doing-log command)))))
 
 
 (provide 'org-doing)

--- a/test/org-doing-test.el
+++ b/test/org-doing-test.el
@@ -11,6 +11,12 @@
    (stub org-doing-done => t)
    (should (org-doing "done some stuff"))))
 
+(ert-deftest org-doing-with-no-command ()
+  "Org-doing omni command with no specific command should default to TODO."
+  (with-mock
+   (stub org-doing-log => t)
+   (should (org-doing "some stuff"))))
+
 (ert-deftest org-doing-done-with-no-arg ()
   "Org-doing omni command should handle done with no additional arguments."
   (with-mock
@@ -20,8 +26,8 @@
 (ert-deftest org-doing-bury-buffer-after-logging ()
   "After logging a task, the buffer should be buried."
   (mocklet (((bury-buffer) :times 2))
-   (org-doing-log "hello"))
-   (org-doing-done "world"))
+   (org-doing-log "hello")
+   (org-doing-done "world")))
 
 (ert-deftest org-doing-save-buffer-after-logging ()
   "After logging a task, the buffer should be saved."


### PR DESCRIPTION
When the string passed to `org-doing` does not start with one of the valid commands, default to passing the whole string to `org-doing-log`.