### PR TITLE
Use org-todo to mark items DONE

### DIFF
--- a/org-doing.el
+++ b/org-doing.el
@@ -86,7 +86,7 @@ TODO item as DONE (see `org-doing-done-most-recent-item'.)"
 (defun org-doing-done-most-recent-item ()
   "Marks the most recent item in `org-doing-file' as DONE."
   (if (search-forward-regexp "^* TODO" nil t)
-    (replace-match "* DONE")))
+    (org-todo 'done)))
 
 ;;;###autoload
 (defun org-doing (command)

--- a/test/org-doing-test.el
+++ b/test/org-doing-test.el
@@ -20,8 +20,8 @@
 (ert-deftest org-doing-bury-buffer-after-logging ()
   "After logging a task, the buffer should be buried."
   (mocklet (((bury-buffer) :times 2))
-   (org-doing-log "hello"))
-   (org-doing-done "world"))
+   (org-doing-log "hello")
+   (org-doing-done "world")))
 
 (ert-deftest org-doing-save-buffer-after-logging ()
   "After logging a task, the buffer should be saved."


### PR DESCRIPTION
Related to #12: when marking an existing item DONE, use `org-todo` rather than simply replacing the text. This allows for other configured org behavior (e.g. using `org-log-done` to add a CLOSED timestamp).

Also fix the (unrelated) test failure for `org-doing-bury-buffer-after-logging` unit test.