### PR TITLE
Refactor file handling; add a command to promote the next LATER item to TODO

### DIFF
--- a/org-doing.el
+++ b/org-doing.el
@@ -57,6 +57,12 @@ Creates the file if it does not already exist.
      (when org-doing-remain-in-buffer
        (switch-to-buffer org-doing-buffer))))
 
+(defun org-doing-find-or-create-file ()
+  (interactive)
+  "Opens the `org-doing-file', creating it if necessary."
+  (let ((org-doing-remain-in-buffer t))
+    (with-org-doing-file)))
+
 (defun initialize-org-doing-buffer ()
   "Prepares the org-doing buffer for use.
 

--- a/org-doing.el
+++ b/org-doing.el
@@ -104,6 +104,12 @@ TODO item as DONE (see `org-doing-done-most-recent-item'.)"
   (if (search-forward-regexp "^* TODO" nil t)
     (org-todo 'done)))
 
+(defun org-doing-start-next ()
+  "Promotes the recent LATER item to TODO."
+  (with-org-doing-file
+    (when (search-forward-regexp "^* LATER" nil t)
+      (org-todo "TODO"))))
+
 ;;;###autoload
 (defun org-doing (command)
   "Interactive function for running any org-doing command.
@@ -112,6 +118,8 @@ The first part of the `command' string is parsed as a command:
 - now: calls `org-doing-log'
 - later: calls `org-doing-log'
 - done: calls `org-doing-done'
+- next: used alone, calls `org-doing-start-next'
+        otherwise calls `org-doing-log'
 
 If no match is found, `org-doing-log' is called and passed the entire
 command string.
@@ -125,6 +133,8 @@ command string.
     (cond ((string= cmd "now") (org-doing-log args))
           ((string= cmd "later") (org-doing-log args t))
           ((string= cmd "done") (org-doing-done args))
+          ((string= cmd "next") (if args (org-doing-log args)
+                                  (org-doing-start-next)))
           (t (org-doing-log command)))))
 
 

--- a/test/org-doing-test.el
+++ b/test/org-doing-test.el
@@ -23,17 +23,28 @@
    (stub org-doing-done => t)
    (should (org-doing "done"))))
 
-(ert-deftest org-doing-bury-buffer-after-logging ()
-  "After logging a task, the buffer should be buried, unless configured otherwise."
-  (mocklet (((bury-buffer) :times 2))
-    (org-doing-log "hello")
-    (org-doing-done "world")
-    (let ((org-doing-bury-buffer nil))
-      (org-doing-log "hello")
-      (org-doing-done "world"))))
 
 (ert-deftest org-doing-save-buffer-after-logging ()
   "After logging a task, the buffer should be saved."
-  (mocklet (((save-buffer) :times 2))
+  (with-mock
+    (mock (save-buffer) => t :times 2)
     (org-doing-log "hello")
     (org-doing-done "world")))
+
+(ert-deftest org-doing-current-buffer-after-logging ()
+  "After logging a task, the current buffer should be restored unless configured otherwise."
+  (with-mock
+    (stub save-buffer => t)
+    (org-doing-log "hello")
+    (org-doing-done "world")
+    (should (not (org-doing-buffer-current-p)))
+    (let ((org-doing-stay-in-buffer t))
+      (org-doing-log "hello")
+      (org-doing-done "world")
+      (should (org-doing-buffer-current-p)))))
+
+(defun org-doing-buffer-current-p ()
+  "Return non-nil if current buffer is visiting the `org-doing-file'."
+  (when buffer-file-name
+    (equal (expand-file-name buffer-file-name)
+           (expand-file-name org-doing-file))))

--- a/test/org-doing-test.el
+++ b/test/org-doing-test.el
@@ -46,10 +46,11 @@
   "After logging a task, the current buffer should be restored unless configured otherwise."
   (with-mock
     (stub save-buffer => t)
-    (org-doing-log "hello")
-    (org-doing-done "world")
-    (should (not (org-doing-buffer-current-p)))
-    (let ((org-doing-stay-in-buffer t))
+    (let ((org-doing-remain-in-buffer nil))
+      (org-doing-log "hello")
+      (org-doing-done "world")
+      (should (not (org-doing-buffer-current-p))))
+    (let ((org-doing-remain-in-buffer t))
       (org-doing-log "hello")
       (org-doing-done "world")
       (should (org-doing-buffer-current-p)))))

--- a/test/org-doing-test.el
+++ b/test/org-doing-test.el
@@ -23,6 +23,17 @@
    (stub org-doing-done => t)
    (should (org-doing "done"))))
 
+(ert-deftest org-doing-next-with-no-arg ()
+  "Org-doing omni command should handle next with no additional arguments."
+  (with-mock
+    (stub org-doing-start-next => t)
+    (should (org-doing "next"))))
+
+(ert-deftest org-doing-next-with--args ()
+  "Org-doing omni command should handle next with arguments."
+  (with-mock
+    (stub org-doing-log => t)
+    (should (org-doing "next some stuff"))))
 
 (ert-deftest org-doing-save-buffer-after-logging ()
   "After logging a task, the buffer should be saved."


### PR DESCRIPTION
Another take on #17, that (for me at least) is more user-friendly than #18.

: Provide a command to update a LATER item to TODO.

Support this via org-doing using the "next" command. When additional input is provided, "next" behaves like "now" and creates a new TODO with the given description. If no additional input is provided, "next" finds the first LATER item in the list and changes it to TODO.

As part of these changes, I introduce a defmacro that can be used to wrap functions that modify the org-doing file. The macro does the following:
 - Visits the org-doing file in a buffer, creating the file if necessary.
 - Evaluates the provided forms. 
 - Saves the org-doing file.
 - Restores the original buffer state, by default. A customization option can be set if you want org-doing commands to keep the org-doing buffer active when they finish.

The buffer handling should be more consistent now. For example, the old implementation would bury the org-doing buffer even if it was active when org-doing was invoked. 

I also tweaked the ert tests. A few of the tests were evaluating commands that actually modify and save the org-doing-file. These tests now stub out the `save-buffer' function so any changes are transient. 